### PR TITLE
Update voice-recorder-card.js

### DIFF
--- a/custom_components/voice_recorder/voice-recorder-card.js
+++ b/custom_components/voice_recorder/voice-recorder-card.js
@@ -264,9 +264,11 @@ class VoiceRecorderCard extends HTMLElement {
                     const result = await response.json();
 
                     if (result.success) {
-                        const notification = `Browserid:${result.browserID}\n Eventname: ${result.eventName}\n Filename: ${result.filename}\n Path: ${result.path}`;
+                        const notification = `Browserid:${result.browserID}\n Eventname: ${result.eventName}\n Filename: ${result.filename}\n Size: ${result.size}\n Path: ${result.path}`;
+                        const notificationID = '${result.size}'
                         this._hass.callService('persistent_notification', 'create', {
                             message: notification,
+                            notification_id: notificationID,
                             title: 'Recording saved successfully'
                         });
                     } else {


### PR DESCRIPTION
Added a notification_id to the persistent notification service. 

I'm using the size as the notification ID so then in the event data, I can use the size to identify the notification so then I can clear the notification from automation (action: persistent_notification.dismiss). Size was the easiest way to create an ID that will likely not be duplicated, but be something identifiable.

The reason for the change is I don't want to clutter my notifications on my kiosks that I have. Another option would be to have a way to disable notifications for successful recordings, but this works for me.