### PR TITLE
docs: clarify that browser_mod/browserID is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ button_mode: click or hold  // The default value is click.
   "size": # File size, 
 }
 ```
-> [!Important]
-> **browserID: You must install <a href='https://github.com/thomasloven/hass-browser_mod'>browser_mod</a> to generate an ID, otherwise it will be displayed as `null`.**
+> [!Tip]
+> **browserID: This is optional. You must install <a href='https://github.com/thomasloven/hass-browser_mod'>browser_mod</a> to generate an ID, otherwise it will be displayed as `null`.**
 
 ## Credits
 


### PR DESCRIPTION
I think it would be better to make it clearer that the addon will work even if browserID is null due to browser_mod not being installed.

Even better would be to explain _why_ you might want to have browswerID. I saw the discussion in https://github.com/kukuxx/HA-Voice-Recorder-Card/issues/3 but I do not understand it enough to add an explanation to the README, as it does not match my simple use-case.